### PR TITLE
Add cmd argument to save EMF model to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ To use it:
 $ java -jar target/pdedependencies2dot-1.0-shaded.jar --allowedPrefixes=org.company --filteredPrefixes=org.eclipse --outputFile=/tmp/mygraph.dot /my/development/folder
 ~~~
 
+
 ## Future work
 
 zest visualization within eclipse?

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Arguments and options:
  --allowedPrefixes=STRING              : List of allowed prefixes. If given, a
                                          found plugin/feature is not taken into
                                          account if its id doesn't match one of
-                                         these prefixes. (default:
-                                         org.eclipse.gemoc)
- --alwaysPrint                         : If set, the output is printed even if
-                                         an output file is given.
+                                         these prefixes.
+ --alwaysPrint                         : If set, the output DOT graph is
+                                         printed even if an output file is
+                                         given.
  --colorSeed=N                         : Seed for the color randomizer. Each
                                          seed is a completely different color
                                          set. (default: 12)
@@ -42,10 +42,12 @@ Arguments and options:
                                          will write into this file instead of
                                          printing to the console. (default:
                                          /tmp/mygraph.dot)
- --outputXMIFile=FILE                  : Path to the XMI output file. If given,
-                                         will write into this file instead of
-                                         printing to the console. (default:
-                                         /tmp/mygraph.dot)
+ --outputXMIFile=FILE                  : Path to the XMI output file which
+                                         contains the intermediate EMF model
+                                         representing the features/plugins and
+                                         their dependencies . If given, will
+                                         write into this file instead of
+                                         printing the DOT graph to the console.
 ~~~~
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Arguments and options:
  --allowedPrefixes=STRING              : List of allowed prefixes. If given, a
                                          found plugin/feature is not taken into
                                          account if its id doesn't match one of
-                                         these prefixes.
+                                         these prefixes. (default:
+                                         org.eclipse.gemoc)
  --alwaysPrint                         : If set, the output DOT graph is
                                          printed even if an output file is
                                          given.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Arguments and options:
                                          will write into this file instead of
                                          printing to the console. (default:
                                          /tmp/mygraph.dot)
- --outputXMIFile=FILE                     : Path to the XMI output file. If given,
+ --outputXMIFile=FILE                  : Path to the XMI output file. If given,
                                          will write into this file instead of
                                          printing to the console. (default:
                                          /tmp/mygraph.dot)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Arguments and options:
                                          will write into this file instead of
                                          printing to the console. (default:
                                          /tmp/mygraph.dot)
+ --outputXMIFile=FILE                     : Path to the XMI output file. If given,
+                                         will write into this file instead of
+                                         printing to the console. (default:
+                                         /tmp/mygraph.dot)
 ~~~~
 
 
@@ -60,7 +64,6 @@ To use it:
 ~~~
 $ java -jar target/pdedependencies2dot-1.0-shaded.jar --allowedPrefixes=org.company --filteredPrefixes=org.eclipse --outputFile=/tmp/mygraph.dot /my/development/folder
 ~~~
-
 
 ## Future work
 

--- a/src/main/java/fr/inria/diverse/pdedependencies2dot/Main.xtend
+++ b/src/main/java/fr/inria/diverse/pdedependencies2dot/Main.xtend
@@ -24,10 +24,10 @@ public class Main {
 	@Option(name="--outputFile", usage="Path to the output file. If given, will write into this file instead of printing to the console.")
 	public File outputFile;
 	
-	@Option(name="--outputXMIFile", usage="Path to the XMI output file. If given, will write into this file instead of printing to the console.")
+	@Option(name="--outputXMIFile", usage="Path to the XMI output file which contains the intermediate EMF model representing the features/plugins and their dependencies . If given, will write into this file instead of printing the DOT graph to the console.")
 	public File outputXMIFile;
 
-	@Option(name="--alwaysPrint", usage="If set, the output is printed even if an output file is given.")
+	@Option(name="--alwaysPrint", usage="If set, the output DOT graph is printed even if an output file is given.")
 	public Boolean alwaysPrint
 
 	@Option(name="--orientation", usage="Sets the overall shape of the graph.")
@@ -84,7 +84,7 @@ public class Main {
 				steptwo.outputFile = outputFile
 
 			if (alwaysPrint !== null || (outputFile === null && outputXMIFile === null))
-				steptwo.alwaysPrint = alwaysPrint
+				steptwo.alwaysPrint = true
 
 			if (orientation !== null)
 				steptwo.orientation = orientation

--- a/src/main/java/fr/inria/diverse/pdedependencies2dot/Main.xtend
+++ b/src/main/java/fr/inria/diverse/pdedependencies2dot/Main.xtend
@@ -72,8 +72,10 @@ public class Main {
 
 			// starting step one	
 			stepone.generate
-			if (outputXMIFile !== null)
+			if (outputXMIFile !== null) {
 				stepone.outputFile = outputXMIFile
+				stepone.saveModelToFile
+			}
 
 			// setting parameter for step two
 			val steptwo = new Model2dot(stepone.graph)
@@ -89,9 +91,6 @@ public class Main {
 
 			if (hideExternal !== null)
 				steptwo.hideExternal = true
-				
-			// starting step one
-			stepone.saveModelToFile
 
 			// starting step two
 			steptwo.generate

--- a/src/main/java/fr/inria/diverse/pdedependencies2dot/Main.xtend
+++ b/src/main/java/fr/inria/diverse/pdedependencies2dot/Main.xtend
@@ -23,6 +23,9 @@ public class Main {
 
 	@Option(name="--outputFile", usage="Path to the output file. If given, will write into this file instead of printing to the console.")
 	public File outputFile;
+	
+	@Option(name="--outputXMIFile", usage="Path to the XMI output file. If given, will write into this file instead of printing to the console.")
+	public File outputXMIFile;
 
 	@Option(name="--alwaysPrint", usage="If set, the output is printed even if an output file is given.")
 	public Boolean alwaysPrint
@@ -69,6 +72,8 @@ public class Main {
 
 			// starting step one	
 			stepone.generate
+			if (outputXMIFile !== null)
+				stepone.outputFile = outputXMIFile
 
 			// setting parameter for step two
 			val steptwo = new Model2dot(stepone.graph)
@@ -76,7 +81,7 @@ public class Main {
 			if (outputFile !== null)
 				steptwo.outputFile = outputFile
 
-			if (alwaysPrint !== null)
+			if (alwaysPrint !== null || (outputFile === null && outputXMIFile === null))
 				steptwo.alwaysPrint = alwaysPrint
 
 			if (orientation !== null)
@@ -84,6 +89,9 @@ public class Main {
 
 			if (hideExternal !== null)
 				steptwo.hideExternal = true
+				
+			// starting step one
+			stepone.saveModelToFile
 
 			// starting step two
 			steptwo.generate

--- a/src/main/java/fr/inria/diverse/pdedependencies2dot/Model2dot.xtend
+++ b/src/main/java/fr/inria/diverse/pdedependencies2dot/Model2dot.xtend
@@ -159,7 +159,7 @@ digraph «graph.name» {
 
 		}
 
-		if(outputFile === null || alwaysPrint) {
+		if(alwaysPrint) {
 			println(result)
 		}
 	}

--- a/src/main/java/fr/inria/diverse/pdedependencies2dot/Model2dot.xtend
+++ b/src/main/java/fr/inria/diverse/pdedependencies2dot/Model2dot.xtend
@@ -1,17 +1,17 @@
 package fr.inria.diverse.pdedependencies2dot
 
+import fr.inria.diverse.pdedependencies2dot.Main.Orientation
+import fr.inria.diverse.pdedependencies2dot.model.Feature
+import fr.inria.diverse.pdedependencies2dot.model.PDEGraph
+import fr.inria.diverse.pdedependencies2dot.model.Plugin
+import fr.inria.diverse.pdedependencies2dot.model.Processeable
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.PrintWriter
-import fr.inria.diverse.pdedependencies2dot.model.PDEGraph
-import fr.inria.diverse.pdedependencies2dot.model.Plugin
-import java.util.Random
-import fr.inria.diverse.pdedependencies2dot.Main.Orientation
-import org.eclipse.xtend.lib.annotations.Accessors
-import fr.inria.diverse.pdedependencies2dot.model.Feature
-import java.util.Map
 import java.util.HashMap
-import fr.inria.diverse.pdedependencies2dot.model.Processeable
+import java.util.Map
+import java.util.Random
+import org.eclipse.xtend.lib.annotations.Accessors
 
 class Model2dot {
 

--- a/src/main/java/fr/inria/diverse/pdedependencies2dot/Pdedependencies2model.xtend
+++ b/src/main/java/fr/inria/diverse/pdedependencies2dot/Pdedependencies2model.xtend
@@ -1,6 +1,13 @@
 package fr.inria.diverse.pdedependencies2dot
 
+import fr.inria.diverse.pdedependencies2dot.model.Feature
+import fr.inria.diverse.pdedependencies2dot.model.ModelFactory
+import fr.inria.diverse.pdedependencies2dot.model.PDEGraph
+import fr.inria.diverse.pdedependencies2dot.model.Plugin
 import java.io.File
+import java.io.FileNotFoundException
+import java.io.PrintWriter
+import java.io.StringWriter
 import java.nio.file.FileSystems
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
@@ -10,32 +17,24 @@ import java.nio.file.SimpleFileVisitor
 import java.nio.file.StandardOpenOption
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.ArrayList
+import java.util.HashMap
 import java.util.HashSet
 import java.util.List
+import java.util.Map
+import java.util.Random
 import java.util.Set
 import java.util.jar.Attributes
 import java.util.jar.Manifest
 import javax.xml.parsers.SAXParser
 import javax.xml.parsers.SAXParserFactory
+import org.eclipse.emf.common.util.URI
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.emf.ecore.resource.URIConverter
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.xml.sax.SAXException
 import org.xml.sax.helpers.DefaultHandler
-import fr.inria.diverse.pdedependencies2dot.model.Feature
-import fr.inria.diverse.pdedependencies2dot.model.ModelFactory
-import fr.inria.diverse.pdedependencies2dot.model.PDEGraph
-import fr.inria.diverse.pdedependencies2dot.model.Plugin
-import java.util.Random
-import java.io.PrintWriter
-import java.io.StringWriter
-
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
-import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.emf.ecore.resource.URIConverter
-import org.eclipse.emf.common.util.URI
-import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl
-import java.io.FileNotFoundException
-import java.util.Map
-import java.util.HashMap
 
 class Pdedependencies2model {
 


### PR DESCRIPTION
This PR is a feature enhancement adding the possibility to save the EMF model created during "stepone" in a XMI file by using the added command line argument `--outputXMIFile`.

Below is the generated XMI file using the [ATL project](https://git.eclipse.org/c/mmt/org.eclipse.atl.git/) as test input : 
* [deps.txt](https://github.com/diverse-project/pdedependencies2dot/files/4050713/deps.txt)
